### PR TITLE
Allow caller to capture exec stdout/stderr

### DIFF
--- a/git/exec.go
+++ b/git/exec.go
@@ -16,9 +16,11 @@ type GitExecBuilder struct {
 	env  nolibgit.Environment
 	repo *git.Repository
 
-	stdin      io.Reader
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+
 	updateRepo bool
-	capture    bool
 	args       []string
 }
 
@@ -27,8 +29,10 @@ func (gs *Client) Exec(name string) *GitExecBuilder {
 		env:  gs.env,
 		repo: gs.repo,
 
+		stdout: io.Discard,
+		stderr: io.Discard,
+
 		updateRepo: true,
-		capture:    true,
 		args:       []string{name},
 	}
 }
@@ -38,8 +42,10 @@ func Exec(env nolibgit.Environment, repo *git.Repository, name string) *GitExecB
 		env:  env,
 		repo: repo,
 
+		stdout: io.Discard,
+		stderr: io.Discard,
+
 		updateRepo: true,
-		capture:    true,
 		args:       []string{name},
 	}
 }
@@ -49,13 +55,18 @@ func (eb *GitExecBuilder) WithStdin(r io.Reader) *GitExecBuilder {
 	return eb
 }
 
-func (eb *GitExecBuilder) SkipUpdate() *GitExecBuilder {
-	eb.updateRepo = false
+func (eb *GitExecBuilder) WithStdout(w io.Writer) *GitExecBuilder {
+	eb.stdout = w
 	return eb
 }
 
-func (eb *GitExecBuilder) SkipCapture() *GitExecBuilder {
-	eb.capture = false
+func (eb *GitExecBuilder) WithStderr(w io.Writer) *GitExecBuilder {
+	eb.stderr = w
+	return eb
+}
+
+func (eb *GitExecBuilder) SkipUpdate() *GitExecBuilder {
+	eb.updateRepo = false
 	return eb
 }
 
@@ -69,10 +80,8 @@ func (eb *GitExecBuilder) Run() error {
 	cmd.Dir = eb.env.WorkingDir
 
 	var out strings.Builder
-	if eb.capture {
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-	}
+	cmd.Stdout = io.MultiWriter(&out, eb.stdout)
+	cmd.Stderr = io.MultiWriter(&out, eb.stderr)
 	if eb.stdin != nil {
 		cmd.Stdin = eb.stdin
 	}
@@ -82,14 +91,12 @@ func (eb *GitExecBuilder) Run() error {
 		return fmt.Errorf("error executing %+v:\n%s", eb.args, out.String())
 	}
 
-	if eb.capture {
-		output := out.String()
-		sc := bufio.NewScanner(strings.NewReader(output))
-		for sc.Scan() {
-			txt := sc.Text()
-			if strings.HasPrefix(txt, `fatal:`) || strings.HasPrefix(txt, `error:`) {
-				return fmt.Errorf("error executing %+v:\n%s", eb.args, output)
-			}
+	output := out.String()
+	sc := bufio.NewScanner(strings.NewReader(output))
+	for sc.Scan() {
+		txt := sc.Text()
+		if strings.HasPrefix(txt, `fatal:`) || strings.HasPrefix(txt, `error:`) {
+			return fmt.Errorf("error executing %+v:\n%s", eb.args, output)
 		}
 	}
 

--- a/git/exec_integration_test.go
+++ b/git/exec_integration_test.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cszczepaniak/go-istage/nolibgit"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,4 +20,38 @@ func TestExec(t *testing.T) {
 
 	err = gs.Exec(`status`).Run()
 	require.NoError(t, err)
+}
+
+func TestExecWithStdout(t *testing.T) {
+	NewTestRepo(t)
+
+	env, err := nolibgit.LoadEnvironment()
+	require.NoError(t, err)
+
+	gs, err := NewClient(env)
+	require.NoError(t, err)
+
+	sb := &strings.Builder{}
+
+	err = gs.Exec(`status`).WithStdout(sb).Run()
+	require.NoError(t, err)
+
+	assert.Equal(t, "On branch master\nnothing to commit, working tree clean\n", sb.String())
+}
+
+func TestExecWithStderr(t *testing.T) {
+	NewTestRepo(t)
+
+	env, err := nolibgit.LoadEnvironment()
+	require.NoError(t, err)
+
+	gs, err := NewClient(env)
+	require.NoError(t, err)
+
+	sb := &strings.Builder{}
+
+	err = gs.Exec(`what`).WithStderr(sb).Run()
+	assert.Error(t, err)
+
+	assert.Equal(t, "git: 'what' is not a git command. See 'git --help'.\n\nThe most similar command is\n\tmktag\n", sb.String())
 }


### PR DESCRIPTION
In order to start replacing libgit2, it will be helpful to be able to capture the output of git commands. Enable this.